### PR TITLE
Fixed right/middle drag disabling after reset()

### DIFF
--- a/src/ofxCameraSaveLoad.cpp
+++ b/src/ofxCameraSaveLoad.cpp
@@ -140,6 +140,7 @@ static void loadEasyCam(ofEasyCam & cam, ofBuffer& buffer){
 	cam.setUpAxis(readValue<v3>("upAxis", buffer, cam.getUpAxis()));
 	cam.setControlArea(readValue<ofRectangle>("controlArea", buffer, cam.getControlArea()));
 #endif
+	cam.setDistance(cam.getDistance()); // WORKAROUND: needed for right/middle drag after reset()
 }
 //----------------------------------------
 bool ofxSaveCamera(const ofNode &node, string savePath){


### PR DESCRIPTION
Hello @roymacdonald. Thank you for having created very cool addon like this :)

I've found a bug which I cannot use right/middle drag after reset (double click) on ofEasyCam. This happens when I used `ofxLoadCamera()` on `setup()`, before when update() or draw() not called.

I needed to add one line to fix this bug. I don't know that this is the best solution, but this is the simplest solution as I think.